### PR TITLE
build(deps): migrate to coil3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,26 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Setup Android SDK
+        run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "build-tools;30.0.3"
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: 11
+          distribution: adopt
+
       - name: Build with Gradle
         run: ./gradlew build -Prelease -PCI --stacktrace

--- a/app-sample/build.gradle
+++ b/app-sample/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 
 def gitSha = { ->
     def output = new ByteArrayOutputStream()
@@ -13,13 +13,16 @@ def gitSha = { ->
 }.memoize()
 
 android {
+    namespace = "io.noties.markwon.app"
 
-    compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
+    buildFeatures {
+        buildConfig true
+    }
 
     defaultConfig {
         applicationId 'io.noties.markwon.app'
-        minSdkVersion 23
+        minSdkVersion config['min-sdk']
+        compileSdkVersion config['compile-sdk']
         targetSdkVersion config['target-sdk']
         versionCode 1
         versionName version
@@ -106,10 +109,6 @@ kapt {
     arguments {
         arg('markwon.samples.file', "${projectDir}/samples.json".toString())
     }
-}
-
-androidExtensions {
-    features = ["parcelize"]
 }
 
 configurations.all {

--- a/app-sample/src/main/AndroidManifest.xml
+++ b/app-sample/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="io.noties.markwon.app">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/app-sample/src/main/java/io/noties/markwon/app/sample/Sample.kt
+++ b/app-sample/src/main/java/io/noties/markwon/app/sample/Sample.kt
@@ -2,7 +2,7 @@ package io.noties.markwon.app.sample
 
 import android.os.Parcelable
 import io.noties.markwon.sample.annotations.MarkwonArtifact
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class Sample(

--- a/app-sample/src/main/java/io/noties/markwon/app/sample/ui/SampleListFragment.kt
+++ b/app-sample/src/main/java/io/noties/markwon/app/sample/ui/SampleListFragment.kt
@@ -43,7 +43,7 @@ import io.noties.markwon.app.utils.tagDisplayName
 import io.noties.markwon.app.widget.SearchBar
 import io.noties.markwon.movement.MovementMethodPlugin
 import io.noties.markwon.sample.annotations.MarkwonArtifact
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 class SampleListFragment : Fragment() {
 
@@ -398,6 +398,7 @@ ${result.throwable.stackTraceString()}
                 when (search) {
                     is SampleSearch.Artifact -> putString(ARG_ARTIFACT, search.artifact.name)
                     is SampleSearch.Tag -> putString(ARG_TAG, search.tag)
+                    else -> Unit
                 }
 
                 val query = search.text

--- a/app-sample/src/main/java/io/noties/markwon/app/samples/image/CoilImageSample.kt
+++ b/app-sample/src/main/java/io/noties/markwon/app/samples/image/CoilImageSample.kt
@@ -1,9 +1,11 @@
 package io.noties.markwon.app.samples.image
 
-import coil.ImageLoader
-import coil.request.Disposable
-import coil.request.ImageRequest
-import coil.transform.CircleCropTransformation
+import coil3.ImageLoader
+import coil3.request.Disposable
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.request.transformations
+import coil3.transform.CircleCropTransformation
 import io.noties.markwon.Markwon
 import io.noties.markwon.app.sample.ui.MarkwonTextViewSample
 import io.noties.markwon.image.AsyncDrawable

--- a/app-sample/src/main/java/io/noties/markwon/app/samples/image/CoilRecyclerViewSample.kt
+++ b/app-sample/src/main/java/io/noties/markwon/app/samples/image/CoilRecyclerViewSample.kt
@@ -1,10 +1,12 @@
 package io.noties.markwon.app.samples.image
 
 import androidx.recyclerview.widget.LinearLayoutManager
-import coil.Coil
-import coil.request.Disposable
-import coil.request.ImageRequest
-import coil.transform.RoundedCornersTransformation
+import coil3.ImageLoader
+import coil3.request.Disposable
+import coil3.request.ImageRequest
+import coil3.request.placeholder
+import coil3.request.transformations
+import coil3.transform.RoundedCornersTransformation
 import io.noties.markwon.Markwon
 import io.noties.markwon.app.R
 import io.noties.markwon.app.sample.ui.MarkwonRecyclerViewSample
@@ -65,7 +67,8 @@ class CoilRecyclerViewSample : MarkwonRecyclerViewSample() {
             disposable.dispose()
           }
         },
-        Coil.imageLoader(context)))
+        ImageLoader(context)
+      ))
       .build()
 
     val adapter = MarkwonAdapter.createTextViewIsRoot(R.layout.adapter_node)

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         jcenter()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.28.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
@@ -34,7 +35,7 @@ task clean(type: Delete) {
 }
 
 wrapper {
-    gradleVersion '6.1.1'
+    gradleVersion '8.2.0'
     distributionType 'all'
 }
 
@@ -49,16 +50,15 @@ if (hasProperty('local')) {
 ext {
 
     config = [
-            'build-tools'    : '30.0.3',
-            'compile-sdk'    : 31,
-            'target-sdk'     : 31,
+            'compile-sdk'    : 34,
+            'target-sdk'     : 34,
             'min-sdk'        : 21,
             'push-aar-gradle': 'https://raw.githubusercontent.com/noties/gradle-mvn-push/master/gradle-mvn-push-aar.gradle'
     ]
 
     final def commonMarkVersion = '0.13.0'
     final def daggerVersion = '2.10'
-    final def coilVersion = '2.2.2'
+    final def coilVersion = '3.0.4'
 
     // please note that `pl.droidsonroids.gif:android-gif-drawable:1.2.15` is used due to the minimum
     // api level mismatch that Markwon supports (16) and later versions of AndroidGifDrawable (17).
@@ -87,8 +87,8 @@ ext {
             'dagger'                  : "com.google.dagger:dagger:$daggerVersion",
             'picasso'                 : 'com.squareup.picasso:picasso:2.71828',
             'glide'                   : 'com.github.bumptech.glide:glide:4.11.0',
-            'coil'                    : "io.coil-kt:coil:$coilVersion",
-            'coil-base'               : "io.coil-kt:coil-base:$coilVersion",
+            'coil'                    : "io.coil-kt.coil3:coil:$coilVersion",
+            'coil-okhttp'             : "io.coil-kt.coil3:coil-network-okhttp:$coilVersion",
             'ix-java'                 : 'com.github.akarnokd:ixjava:1.0.0',
             'gson'                    : 'com.google.code.gson:gson:2.8.6',
             'commons-io'              : 'commons-io:commons-io:2.6'
@@ -129,11 +129,6 @@ def registerArtifact(project) {
     }
 
     project.afterEvaluate {
-
-        // disable generation of BuildConfig files
-        project.generateDebugBuildConfig.enabled = false
-        project.generateReleaseBuildConfig.enabled = false
-
         // print test status (for CI)
         project.android.testOptions.unitTests.all {
             testLogging {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/markwon-core/build.gradle
+++ b/markwon-core/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-core/src/main/AndroidManifest.xml
+++ b/markwon-core/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon" />
+<manifest />

--- a/markwon-editor/build.gradle
+++ b/markwon-editor/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.editor"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-editor/src/main/AndroidManifest.xml
+++ b/markwon-editor/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.editor" />
+<manifest />

--- a/markwon-ext-latex/build.gradle
+++ b/markwon-ext-latex/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.ext.latex"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-ext-latex/src/main/AndroidManifest.xml
+++ b/markwon-ext-latex/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.ext.latex" />
+<manifest />

--- a/markwon-ext-strikethrough/build.gradle
+++ b/markwon-ext-strikethrough/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.ext.strikethrough"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-ext-strikethrough/src/main/AndroidManifest.xml
+++ b/markwon-ext-strikethrough/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.ext.strikethrough" />
+<manifest />

--- a/markwon-ext-tables/build.gradle
+++ b/markwon-ext-tables/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.ext.tables"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-ext-tables/src/main/AndroidManifest.xml
+++ b/markwon-ext-tables/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.ext.tables" />
+<manifest />

--- a/markwon-ext-tasklist/build.gradle
+++ b/markwon-ext-tasklist/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.ext.tasklist"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-ext-tasklist/src/main/AndroidManifest.xml
+++ b/markwon-ext-tasklist/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.ext.tasklist" />
+<manifest />

--- a/markwon-html/build.gradle
+++ b/markwon-html/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.html"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-html/src/main/AndroidManifest.xml
+++ b/markwon-html/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.html" />
+<manifest />

--- a/markwon-image-coil/build.gradle
+++ b/markwon-image-coil/build.gradle
@@ -2,30 +2,34 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
 
 android {
+    namespace = "io.noties.markwon.image.coil"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']
         targetSdkVersion config['target-sdk']
     }
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {
     implementation "io.noties.markwon:core:4.6.2"
-
-    // @since 4.5.1 declare `coil-base` as api dependency (would require users
-    //  to have explicit coil dependency)
-    api deps['coil-base']
-    compileOnly deps['coil']
+    api deps['coil-okhttp']
+    api deps['coil']
 }
 
 afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
-                from components.release
+                 from components.release
 
                 groupId = 'dev.jeziellago.markwon'
                 artifactId = 'image-coil'

--- a/markwon-image-coil/src/main/AndroidManifest.xml
+++ b/markwon-image-coil/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.image.coil" />
+<manifest />

--- a/markwon-image-glide/build.gradle
+++ b/markwon-image-glide/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.image.glide"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-image-glide/src/main/AndroidManifest.xml
+++ b/markwon-image-glide/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.image.glide" />
+<manifest />

--- a/markwon-image-picasso/build.gradle
+++ b/markwon-image-picasso/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.image.picasso"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-image-picasso/src/main/AndroidManifest.xml
+++ b/markwon-image-picasso/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.image.picasso" />
+<manifest />

--- a/markwon-image/build.gradle
+++ b/markwon-image/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.image"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-image/src/main/AndroidManifest.xml
+++ b/markwon-image/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.image" />
+<manifest />

--- a/markwon-inline-parser/build.gradle
+++ b/markwon-inline-parser/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.inline.parser"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-inline-parser/src/main/AndroidManifest.xml
+++ b/markwon-inline-parser/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.inlineparser" />
+<manifest />

--- a/markwon-linkify/build.gradle
+++ b/markwon-linkify/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.linkify"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-linkify/src/main/AndroidManifest.xml
+++ b/markwon-linkify/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.linkify" />
+<manifest />

--- a/markwon-recycler-table/build.gradle
+++ b/markwon-recycler-table/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.recycler.table"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-recycler-table/src/main/AndroidManifest.xml
+++ b/markwon-recycler-table/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.recycler.table" />
+<manifest />

--- a/markwon-recycler/build.gradle
+++ b/markwon-recycler/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.recycler"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-recycler/src/main/AndroidManifest.xml
+++ b/markwon-recycler/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.recycler" />
+<manifest />

--- a/markwon-simple-ext/build.gradle
+++ b/markwon-simple-ext/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.simple.ext"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-simple-ext/src/main/AndroidManifest.xml
+++ b/markwon-simple-ext/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.simple.ext" />
+<manifest />

--- a/markwon-syntax-highlight/build.gradle
+++ b/markwon-syntax-highlight/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.syntax.highlight"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-syntax-highlight/src/main/AndroidManifest.xml
+++ b/markwon-syntax-highlight/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.syntax" />
+<manifest />

--- a/markwon-test-span/build.gradle
+++ b/markwon-test-span/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "io.noties.markwon.test.span"
 
     compileSdkVersion config['compile-sdk']
-    buildToolsVersion config['build-tools']
 
     defaultConfig {
         minSdkVersion config['min-sdk']

--- a/markwon-test-span/src/main/AndroidManifest.xml
+++ b/markwon-test-span/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="io.noties.markwon.test" />
+<manifest />


### PR DESCRIPTION
PR was made for dependency consistencies for compose-markdown. The said repo has the following dependency:
```kotlin
implementation "com.github.jeziellago:Markwon:58aa5aba6a"
```
So I think its only right to update that dependency too in order to migrate to coil3.

Here's my current test publish (in jitpack):
```kotlin
implementation "com.github.rhenwinch:Markwon:58b84bc918"
```

Will be a useful migration for the compose-markdown repo. I already have a queued PR for compose-markdown coil3 migration which is included in this [fork branch](https://github.com/rhenwinch/compose-markdown/tree/coil3). 

Related to https://github.com/jeziellago/compose-markdown/issues/139